### PR TITLE
fix fixtures array (maybe)

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,7 +128,7 @@ Suite.prototype.run = function(options, cb, thisArg) {
           }
         },
         fn: function () {
-          fn.apply(thisArg, args);
+          fn.call(thisArg, args);
           return;
         }
       });


### PR DESCRIPTION
When running benchmarks for https://github.com/jonschlinkert/array-unique I've noticed strange results.

The functions in https://github.com/jonschlinkert/array-unique/tree/master/benchmark/code were receiving not arrays, as first argument, but applied values.

I've tracked the bug to this line, and with this change the benchmarks for https://github.com/jonschlinkert/array-unique seems to run fine.

However, without tests, I'm not sure if this change is what needs to be done here. Maybe it'll break some other use cases for benchmarked.

JFYI anyways
