### PR TITLE
Revet regression from 89e721a

### DIFF
--- a/index.js
+++ b/index.js
@@ -294,7 +294,12 @@ Benchmarked.prototype.addSuite = function(fixture) {
         cursor.write('  ' + event.target);
       },
       fn: function() {
-        file.run.apply(null, fixture.content);
+        var args = fixture.content;
+        if (Array.isArray(args[0])) {
+          file.run.apply(null, args);
+        } else {
+          file.run(args);
+        }
         return;
       },
       onComplete: function() {


### PR DESCRIPTION
If you clone this repo and run `node example` with Node v4, v5, v6, or v7, it doesn't actually run the tests. This commit fixes that.

In the commit 89e721a there were two changes. The first was fine, so this commit does not revert that change.

But the second change made in 89e721a was a major regression. It's all about calling `Function.prototype.apply` supplying `fixture.content` as the array of arguments. Inspecting the definition of that `fixture.contents` ([line 47](https://github.com/jonschlinkert/benchmarked/blob/2a2755a80081215968d60b0a4ad77dcca4aae830/index.js#L47)) reveals that the property comes from a module called `file-reader` which [returns objects, not arrays](https://github.com/jonschlinkert/file-reader/tree/2b6abe1423ba1b76cc339039e2339862664c42ba#usage). `Function.prototype.apply` is [inappropriate for objects](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply), so this commit ensures that `Function.prototype.apply` is not used (unless for some reason `fixture.content` happens to be array-like).