### PR TITLE
Fix link to examples directory in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ var suite = require('benchmarked')({
 suite.run();
 ```
 
-See the [examples](./example) to get a better understanding of how this works.
+See the [examples](./examples) to get a better understanding of how this works.
 
 ## API
 


### PR DESCRIPTION
Commit fbf093e renamed the directory example to examples. However, it did not update the README to reflect this change.