### PR TITLE
Add format option

### DIFF
--- a/.verb.md
+++ b/.verb.md
@@ -6,7 +6,12 @@ This is an opinionated wrapper for [benchmarked.js](http://benchmarkjs.com/) to 
 var suite = require('{%= name %}')({
   cwd: 'benchmark',              // optionally define a base directory for code and fixtures
   fixtures: 'my-fixtures/*.txt', // path or glob pattern to fixtures
-  code: 'my-functions/*.js'      // path or glob pattern to code files
+  code: 'my-functions/*.js',     // path or glob pattern to code files
+  format: function(benchmark) {
+    // optionally override default formatting.
+    // return a string.
+    // see examples/basic.js for a real example.
+  }
 });
 
 // run the benchmarks

--- a/examples/basic.js
+++ b/examples/basic.js
@@ -4,8 +4,19 @@ var Suite = require('..');
 var suite = new Suite({
   fixtures: 'fixtures/*.txt',
   code: 'code/*.js',
-  cwd: __dirname
+  cwd: __dirname,
+  format: function(benchmark) {
+    // this is how `benchmark` builds its toString() value
+    // in default format: '  ' + benchmark
+    var name = benchmark.name;
+    var ops = bm.hz.toFixed(bm.hz < 100 ? 2 : 0);
+    var rme = '\xb1' + benchmark.stats.rme.toFixed(2) + '%';
+    var size = benchmark.stats.sample.length;
+    var ess  = benchmark.stats.sample.length === 1 ? '' : 's';
+
+    return name + ' x ' + ops + ' ops/sec ' + rme + ' (' + size +
+      ' run' + ess + ' sampled)';
+  }
 });
 
 suite.run();
-

--- a/index.js
+++ b/index.js
@@ -57,6 +57,10 @@ Benchmarked.prototype.defaults = function(benchmarked) {
     }
   };
 
+  this.format = function(benchmark) {
+    return '  ' + benchmark;
+  };
+
   if (this.options.fixtures) {
     this.addFixtures(this.options.fixtures);
   }
@@ -291,7 +295,7 @@ Benchmarked.prototype.addSuite = function(fixture) {
       onCycle: function onCycle(event) {
         cursor.horizontalAbsolute();
         cursor.eraseLine();
-        cursor.write('  ' + event.target);
+        cursor.write(opts.format(event.target));
       },
       fn: function() {
         var args = fixture.content;


### PR DESCRIPTION
This changes:

1. moves `'  ' + benchmark` into its own function named `format` which is set in the default options object.
2. then uses `opts.format(event.target)` in its place in `addSuite()`
3. user can override `format` by providing it to `new Benchmarked`.
4. show overriding `format` in the README (via .verb.md template)
5. show real example of overriding `format` in `examples/basic.js`. It shows how to build the default string.

