### PR TITLE
cache node_modules on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ os:
   - linux
   - osx
 language: node_js
+cache:
+  directories:
+    - node_modules
 node_js:
   - node
   - '7'


### PR DESCRIPTION
Helps speedup Travis CI builds by reducing downloads.